### PR TITLE
Enable trust proxy for Heroku HTTPS detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var dashboard = new ParseDashboard({
 });
 
 var app = express();
+app.enable('trust proxy');
 
 // make the Parse Dashboard available at /
 app.use('/', dashboard);


### PR DESCRIPTION
Fixes #1
