### PR TITLE
Fix Syntax Error and Allow for Remote Login

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "value": "stefanayala3266@gmail.com"
     },
     "PASSWORD": {
-      "description": "The password of the account to log into the dashboard.",
+      "description": "The password of the account to log into your dashboard.",
       "value": "parse"
     }
   },

--- a/app.json
+++ b/app.json
@@ -20,6 +20,14 @@
     "APP_NAME": {
       "description": "The name of the app that will show up in the dashboard.",
       "value": "myAppName"
+    },
+    "USERNAME": {
+      "description": "The username of the account to log into the dashboard.",
+      "value": "stefanayala3266@gmail.com"
+    },
+    "PASSWORD": {
+      "description": "The password of the account to log into the dashboard.",
+      "value": "parse"
     }
   },
   "image": "heroku/nodejs"

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var dashboard = new ParseDashboard({
       serverURL: process.env.SERVER_URL || herokuParseServer || localParseServer,
       appName: process.env.APP_NAME || 'MyApp',
       users: [
-        { user: process.env.USERNAME, pass: process.env.PASSWORD }
+        { user: "username", pass: "password" }
       ],
       trustProxy: 1
     },

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ var dashboard = new ParseDashboard({
       trustProxy: 1
     },
   ],
+  users: [
+    { user: "username", pass: "password" }
+  ],
+  trustProxy: 1
 });
 
 var app = express();

--- a/index.js
+++ b/index.js
@@ -4,12 +4,11 @@ var express = require('express');
 var ParseDashboard = require('parse-dashboard');
 var path = require('path');
 
-var dashboard = new ParseDashboard({
-  let localParseServer = 'http://localhost:1337/parse';
-
+let localParseServer = 'http://localhost:1337/parse';
   // Heroku requires HTTPS. Please read the README file for details.
-  // let herokuParseServer = 'https://my-parse-dashboard.herokuapp.com/parse'
+let herokuParseServer = 'https://my-parse-dashboard.herokuapp.com/parse';
 
+var dashboard = new ParseDashboard({
   apps: [
     {
       appId: process.env.APP_ID || 'myAppId',

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var express = require('express');
 var ParseDashboard = require('parse-dashboard');
 var path = require('path');
+var config = require('./config.json');
 
 let localParseServer = 'http://localhost:1337/parse';
   // Heroku requires HTTPS. Please read the README file for details.
@@ -15,6 +16,7 @@ var dashboard = new ParseDashboard({
       masterKey: process.env.MASTER_KEY || 'myMasterKey',
       serverURL: process.env.SERVER_URL || herokuParseServer || localParseServer,
       appName: process.env.APP_NAME || 'MyApp',
+      users: config.users
     },
   ],
 });

--- a/index.js
+++ b/index.js
@@ -15,14 +15,10 @@ var dashboard = new ParseDashboard({
       masterKey: process.env.MASTER_KEY || 'myMasterKey',
       serverURL: process.env.SERVER_URL || herokuParseServer || localParseServer,
       appName: process.env.APP_NAME || 'MyApp',
-      users: [
-        { user: "username", pass: "password" }
-      ],
-      trustProxy: 1
     },
   ],
   users: [
-    { user: "username", pass: "password" }
+    { user: process.env.USERNAME, pass: process.env.PASSWORD }
   ],
   trustProxy: 1
 });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var express = require('express');
 var ParseDashboard = require('parse-dashboard');
 var path = require('path');
-var config = require('./config.json');
 
 let localParseServer = 'http://localhost:1337/parse';
   // Heroku requires HTTPS. Please read the README file for details.
@@ -16,7 +15,9 @@ var dashboard = new ParseDashboard({
       masterKey: process.env.MASTER_KEY || 'myMasterKey',
       serverURL: process.env.SERVER_URL || herokuParseServer || localParseServer,
       appName: process.env.APP_NAME || 'MyApp',
-      users: config.users
+      users: [
+        { user: process.env.USERNAME, pass: process.env.PASSWORD }
+      ]
     },
   ],
 });

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ var dashboard = new ParseDashboard({
       appName: process.env.APP_NAME || 'MyApp',
       users: [
         { user: process.env.USERNAME, pass: process.env.PASSWORD }
-      ]
+      ],
+      trustProxy: 1
     },
   ],
 });


### PR DESCRIPTION
These are the changes I had to make in order to get this working today. With these changes I am able to deploy this to heroku and use ENV vars to set a default user and password through Heroku Config Vars.

This was a bit sloppy but this resolves https://github.com/cherukumilli/parse-dashboard-example/issues/7 and also allows for remote login (this wasn't possible before).

Feel free to clean it up